### PR TITLE
Update `shouldBeDefined` `val` argument to allow any value type

### DIFF
--- a/lib/errr/validator.js
+++ b/lib/errr/validator.js
@@ -16,7 +16,7 @@ class ErrrValidator {
   /**
    * Throws an error if 'val' is not defined.
    *
-   * @param {String} val - The value to validate.
+   * @param {*} val - The value to validate.
    * @param {String} [message] - The error message or the error template string to use if the ErrrValidator fails.
    * @param {Array} [template] - Template params.  If provided, the error message will be generated using util.format(message, template).
    * @returns {ErrrDecorator} - An object that decorates the errr node module.


### PR DESCRIPTION
Correct me if I'm wrong, but type `String` seems to be a mistake here. We use `shouldBeDefined` to check definition for any kind of value, not just strings.